### PR TITLE
Add OneDev as Github alternative

### DIFF
--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -258,6 +258,16 @@
           "deploy": "https://marketplace.digitalocean.com/apps/gitea"
         },
         {
+          "name": "OneDev",
+          "stars": "2.7K",
+          "license": "MIT",
+          "svg": "https://code.onedev.io/img/logo.png",
+          "site": "https://code.onedev.io/",
+          "language": "Java",
+          "repo": "theonedev/onedev",
+          "deploy": "https://code.onedev.io/projects/onedev-manual/blob/master/pages/installation-guide.md"
+        },
+        {
           "name": "Pagure",
           "stars": "158",
           "license": "GPL v2+",


### PR DESCRIPTION
OneDev is a Java-based all-in-one DevOps platform, with features like
git management, issue tracking, CI, ...