### PR TITLE
use gogs actual logo

### DIFF
--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -231,7 +231,7 @@
           "name": "Gogs",
           "stars": "33.5K",
           "license": "MIT",
-          "svg": "https://gogs.io/img/favicon.ico",
+          "svg": "https://avatars2.githubusercontent.com/u/6656686?s=400&v=4",
           "site": "https://gogs.io/",
           "language": "GO",
           "repo": "gogs/gogs",


### PR DESCRIPTION
before (also `*.ico` are hidden by some adblockers):
![](https://gogs.io/img/favicon.ico)

after:
![](https://avatars2.githubusercontent.com/u/6656686?s=400&v=4)