### PR TITLE
Fix GitHub URL

### DIFF
--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -225,7 +225,7 @@
       "website": "https://heroku.com"
     },
     {
-      "main": "Github",
+      "main": "GitHub",
       "alts": [
         {
           "name": "Gogs",
@@ -270,7 +270,7 @@
       ],
       "id": "8bxlppy5h",
       "svg": "https://github.githubassets.com/images/modules/logos_page/GitHub-Logo.png",
-      "website": "https://github"
+      "website": "https://github.com"
     },
     {
       "main": "1Password",


### PR DESCRIPTION
This PR fixes the GitHub URL which is currently pointing to `https://github` instead of `https://github.com`