### PR TITLE
Add LogChimp as canny replacement

### DIFF
--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -1132,6 +1132,16 @@
           "stars": "599",
           "license": "GPL V3",
           "svg": "https://ph-files.imgix.net/be9188f7-f8a4-4959-9b3a-e685c5a9f364?auto=format"
+        },
+        {
+          "name": "LogChimp",
+          "deploy": "https://logchimp.codecarrot.net/download",
+          "site": "https://logchimp.codecarrot.net/",
+          "language": "NODE",
+          "repo": "logchimp/logchimp",
+          "stars": "140",
+          "license": "Apache-2.0 License",
+          "svg": "https://cdn.logchimp.codecarrot.net/logchimp_circular_logo.png"
         }
       ],
       "id": "weirgeywu",


### PR DESCRIPTION
Add LogChimp product as canny alternative in product management category.