### PR TITLE
Remove Openship

### DIFF
--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -1357,16 +1357,6 @@
         }
       ],
       "alts": [
-        {
-          "name": "Openship",
-          "stars": "74",
-          "license": "GPL V3",
-          "repo": "openshiporg/openship",
-          "svg": "https://user-images.githubusercontent.com/34615258/75076255-4750f580-54c5-11ea-9b9e-21ede0e13a09.png",
-          "site": "https://openship.org",
-          "language": "JS",
-          "deploy": "https://zeit.co/import/project?template=https://github.com/openshiporg/openship"
-        }
       ],
       "id": "5uv2jsadu",
       "category": "E-commerce"


### PR DESCRIPTION
Removal of Openship because openship has gone closed source. (See their github for the statement) https://github.com/openshiporg/openship