### PR TITLE
fix id in alts.json

### DIFF
--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -20,7 +20,7 @@
           "language": "Elixir/Ruby"
         }
       ],
-      "id": "",
+      "id": "8w6afb14",
       "category": "Security"
     },
     {


### PR DESCRIPTION
Sorry, never worked with Tina CMS before. Looks like setting the id as "" merges the results with the Notion alternatives. I just set a unique id manually.

Let me know if that would fix it, thanks!