### PR TITLE
Add Eqivo as Twilio alternative

### DIFF
--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -1814,6 +1814,29 @@
       ],
       "id": "xj4jiofj",
       "category": "OS"
-    }
+    },
+    {
+      "commercial": [
+        {
+          "main": "Twilio",
+          "website": "https://twilio.com",
+          "svg": "https://upload.wikimedia.org/wikipedia/commons/7/7e/Twilio-logo-red.svg"
+        }
+      ],
+      "alts": [
+        {
+          "name": "Eqivo",
+          "repo": "rtckit/eqivo",
+          "site": "https://eqivo.org/",
+          "license": "MIT",
+          "stars": "3",
+          "svg": "https://raw.github.com/rtckit/media/master/eqivo/readme-splash.png",
+          "language": "PHP",
+          "deploy": "https://eqivo.org/#getting-started"
+        }
+      ],
+      "id": "bfrx789j",
+      "category": "Communication"
+    },
   ]
 }

--- a/content/alts/alts.json
+++ b/content/alts/alts.json
@@ -1837,6 +1837,6 @@
       ],
       "id": "bfrx789j",
       "category": "Communication"
-    },
+    }
   ]
 }


### PR DESCRIPTION
Adds Twilio and Eqivo as an open source alternative.

The business problem they address is simplifying the interaction between traditional web applications and voice/video-enabled endpoints (traditional PSTN lines, VoIP phones, webRTC clients etc.) thus lowering the entry barrier for VoIP integrations.